### PR TITLE
Simple fix for YTAS problems

### DIFF
--- a/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/f.glif
+++ b/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/f.glif
@@ -19,17 +19,17 @@
       <point x="485" y="1193"/>
       <point x="382" y="1123"/>
       <point x="382" y="1070" type="qcurve" smooth="yes"/>
-      <point x="382" y="992" type="line"/>
-      <point x="382" y="970" type="line"/>
+      <point x="382" y="922" type="line"/>
+      <point x="382" y="900" type="line"/>
       <point x="382" y="0" type="line"/>
     </contour>
     <contour>
-      <point x="25" y="910" type="line"/>
-      <point x="25" y="1052" type="line"/>
-      <point x="266" y="1052" type="line"/>
-      <point x="312" y="1052" type="line"/>
-      <point x="610" y="1052" type="line"/>
-      <point x="610" y="910" type="line"/>
+      <point x="25" y="840" type="line"/>
+      <point x="25" y="982" type="line"/>
+      <point x="266" y="982" type="line"/>
+      <point x="312" y="982" type="line"/>
+      <point x="610" y="982" type="line"/>
+      <point x="610" y="840" type="line"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/i.glif
+++ b/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/i.glif
@@ -10,18 +10,18 @@
       <point x="343" y="0" type="line"/>
     </contour>
     <contour>
-      <point x="134" y="1260" type="qcurve" smooth="yes"/>
-      <point x="134" y="1307"/>
-      <point x="194" y="1371"/>
-      <point x="250" y="1371" type="qcurve" smooth="yes"/>
-      <point x="306" y="1371"/>
-      <point x="366" y="1307"/>
-      <point x="366" y="1260" type="qcurve" smooth="yes"/>
-      <point x="366" y="1213"/>
-      <point x="306" y="1149"/>
-      <point x="250" y="1149" type="qcurve" smooth="yes"/>
-      <point x="194" y="1149"/>
-      <point x="134" y="1213"/>
+      <point x="134" y="1330" type="qcurve" smooth="yes"/>
+      <point x="134" y="1377"/>
+      <point x="194" y="1441"/>
+      <point x="250" y="1441" type="qcurve" smooth="yes"/>
+      <point x="306" y="1441"/>
+      <point x="366" y="1377"/>
+      <point x="366" y="1330" type="qcurve" smooth="yes"/>
+      <point x="366" y="1283"/>
+      <point x="306" y="1219"/>
+      <point x="250" y="1219" type="qcurve" smooth="yes"/>
+      <point x="194" y="1219"/>
+      <point x="134" y="1283"/>
     </contour>
   </outline>
 </glyph>

--- a/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/j.glif
+++ b/sources/1A-drawings/Parametric Axes/RobotoFlex_YTAS649.ufo/glyphs/j.glif
@@ -22,18 +22,18 @@
       <point x="-69" y="-419"/>
     </contour>
     <contour>
-      <point x="134" y="1260" type="qcurve" smooth="yes"/>
-      <point x="134" y="1307"/>
-      <point x="194" y="1371"/>
-      <point x="250" y="1371" type="qcurve" smooth="yes"/>
-      <point x="306" y="1371"/>
-      <point x="366" y="1307"/>
-      <point x="366" y="1260" type="qcurve" smooth="yes"/>
-      <point x="366" y="1213"/>
-      <point x="306" y="1149"/>
-      <point x="250" y="1149" type="qcurve" smooth="yes"/>
-      <point x="194" y="1149"/>
-      <point x="134" y="1213"/>
+      <point x="134" y="1330" type="qcurve" smooth="yes"/>
+      <point x="134" y="1377"/>
+      <point x="194" y="1441"/>
+      <point x="250" y="1441" type="qcurve" smooth="yes"/>
+      <point x="306" y="1441"/>
+      <point x="366" y="1377"/>
+      <point x="366" y="1330" type="qcurve" smooth="yes"/>
+      <point x="366" y="1283"/>
+      <point x="306" y="1219"/>
+      <point x="250" y="1219" type="qcurve" smooth="yes"/>
+      <point x="194" y="1219"/>
+      <point x="134" y="1283"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
These are naive, partial fixes for the YTAS issues with `i`, `j` and `f`. For the `i`-dot, it would be better to have a special bold master that compresses the dots, and they would benefit from being components. But this simply does not lower the `i`-dots so much, and lowers the `f`-bar a bit.

- https://github.com/googlefonts/roboto-flex/issues/319
- https://github.com/googlefonts/roboto-flex/issues/314